### PR TITLE
Add missing src directory

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -5,7 +5,7 @@ test -f ~/bootstrapped && exit
 
 wget -q https://github.com/docker/containerd/releases/download/0.0.4/containerd-linux64 -O containerd
 wget -q https://github.com/docker/containerd/releases/download/0.0.4/ctr-linux64 -O ctr
-chmod +x containerd && sudo mv  /usr/local/bin
+chmod +x containerd && sudo mv containerd /usr/local/bin
 chmod +x ctr && sudo mv ctr /usr/local/bin
 
 date > ~/bootstrapped


### PR DESCRIPTION
Getting the following error when I run `vagrant up`.

```
==> default: Running provisioner: shell...
    default: Running: /var/folders/wt/qqzg15s11w7_gs8jlllbz9bc0000gn/T/vagrant-shell20160809-53782-gdq2ox.sh
==> default: mv:
==> default: missing destination file operand after ‘/usr/local/bin’
==> default: Try 'mv --help' for more information.
```
